### PR TITLE
Copy cargo.lock in Dockerfile.konflux and bump rust-toolchain

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -31,7 +31,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ## Gateway builder #########################################################
 FROM rust-builder AS gateway-builder
 
-COPY *.toml /app/
+COPY *.toml Cargo.lock /app/
 COPY src/ /app/src/
 # COPY config/config.yaml /app/config/config.yaml
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Attempting to deal with the konflux build issues