### PR TITLE
:memo: upgrade channel to 1.86.0

### DIFF
--- a/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
+++ b/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     - io.openshift.tags=odh-trustyai-vllm-orchestrator-gateway
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-trustyai-vllm-orchestrator-gateway-{{revision}}
+  - name: rhoai-version
+    value: "3.3.2"
   - name: dockerfile
     value: Dockerfile.konflux
   - name: path-context

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Trying to fix build image failure by bumping to 1.86 to [RHOAIENG-58186)](https://redhat.atlassian.net/browse/RHOAIENG-58186)