### PR TITLE
  Fix: Copy Cargo.lock and add --locked to prevent edition2024 errors

### DIFF
--- a/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
+++ b/.tekton/odh-trustyai-vllm-orchestrator-gateway-pull-request.yaml
@@ -49,6 +49,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: rhoai-version
+    value: "2.25.0"
   pipelineRef:
     resolver: git
     params:

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -32,12 +32,13 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 FROM rust-builder AS gateway-builder
 
 COPY *.toml /app/
+COPY Cargo.lock /app/
 COPY src/ /app/src/
 # COPY config/config.yaml /app/config/config.yaml
 
 WORKDIR /app
 
-RUN cargo install --root /app/ --path .
+RUN cargo install --locked --root /app/ --path .
 
 ## Tests stage ##################################################################
 FROM gateway-builder AS tests


### PR DESCRIPTION
What was wrong:
  1. Cargo.lock wasn't being copied into the Docker container (line 34 only copied *.toml)
  2. cargo install command lacked the --locked flag

  Test results:
  -  Local podman build: SUCCESS in 59.98s
  - Uses correct dependencies (hashbrown 0.15.4, indexmap 2.6.0)
  - No edition2024 errors
  - Binary created successfully

